### PR TITLE
Flatten csv and pass variables ti custom functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dmypy.json
 
 #Visual code
 .vscode
+
+#Pycharm
+.idea

--- a/RecordMapper/RecordMapper.py
+++ b/RecordMapper/RecordMapper.py
@@ -90,7 +90,7 @@ class RecordMapper(object):
         base_flat_schema = self.flat_schemas[base_schema_name]
         nested_flat_schema = self.flat_schemas[nested_schema_name]
 
-        base_flat_schema.update(nested_flat_schema)
+#        base_flat_schema.update(nested_flat_schema)
 
         flat_record = FlatRecordBuilder.get_flat_record_from_normal_record(record)
 
@@ -167,9 +167,6 @@ class RecordMapper(object):
         )
         writer.write_records(records_list, output_opts)
         writer.close()
-
-        for record in records_list:
-            print(records_list)
 
         if "csv" in paths_to_write:
 

--- a/RecordMapper/appliers/NestedSchemaSelectorApplier.py
+++ b/RecordMapper/appliers/NestedSchemaSelectorApplier.py
@@ -62,7 +62,7 @@ class NestedSchemaSelectorApplier(object):
         :rtype: dict
         """
 
-        nested_schema_name = field_data.selector(field_key, record, self.custom_variables)
+        nested_schema_name = field_data.selector(field_key, record)
 
         # Not schema selected (this field will be null)
         if nested_schema_name is None:

--- a/RecordMapper/appliers/NestedSchemaSelectorApplier.py
+++ b/RecordMapper/appliers/NestedSchemaSelectorApplier.py
@@ -62,7 +62,8 @@ class NestedSchemaSelectorApplier(object):
         :rtype: dict
         """
 
-        nested_schema_name = field_data.selector(field_key, record) if field_data.selector != None and field_data.selector(field_key, record) != None else None
+        nested_schema_name = field_data.selector(field_key, record, self.custom_variables) \
+            if field_data.selector != None and field_data.selector(field_key, record, self.custom_variables) != None else None
 
         # Not schema selected (this field will be null)
         if nested_schema_name == None:

--- a/RecordMapper/appliers/NestedSchemaSelectorApplier.py
+++ b/RecordMapper/appliers/NestedSchemaSelectorApplier.py
@@ -1,5 +1,5 @@
 from typing import Dict
-
+from RecordMapper.builders.FlatSchemaBuilder import FieldData
 
 class NestedSchemaSelectorApplier(object):
     """An applier that modifies a FlatSchema selecting multiple nested schemas using
@@ -45,7 +45,7 @@ class NestedSchemaSelectorApplier(object):
         return (record, complete_flat_schema)
 
     def select_nested_schema_and_add_their_fields(self, record: dict, flat_schema: dict, field_key: str,
-                                                  field_data: tuple) -> dict:
+                                                  field_data: FieldData) -> dict:
         """Select a nested schema for a field (using the defined function in "selector" value of the FieldData) and add their fields
         to the resulting flat schema.
 
@@ -62,10 +62,10 @@ class NestedSchemaSelectorApplier(object):
         :rtype: dict
         """
 
-        nested_schema_name = field_data.selector(field_key, record)
+        nested_schema_name = field_data.selector(field_key, record) if field_data.selector != None and field_data.selector(field_key, record) != None else None
 
         # Not schema selected (this field will be null)
-        if nested_schema_name is None:
+        if nested_schema_name == None:
             return flat_schema
 
         # Schema selected. Add their fields to the complete schema

--- a/RecordMapper/avro/AvroWriter.py
+++ b/RecordMapper/avro/AvroWriter.py
@@ -18,7 +18,7 @@ class AvroWriter(Writer):
 
     def __init__(self, obj_to_write: object, base_schema: dict, nested_schemas: List[dict] = []):
         """AvroWriter constructor
-        
+
         :param output_stream: The file-like object where data will be writed.
         :type output_stream: file
         :param avro_schema: A valid avro schema as a dict.
@@ -29,9 +29,9 @@ class AvroWriter(Writer):
         self.write_options = "wb"
 
         self.parsed_nested_schemas = [fastavro.parse_schema(schema) for schema in nested_schemas]
-        self.parsed_base_schema = fastavro.parse_schema(base_schema) 
+        self.parsed_base_schema = fastavro.parse_schema(base_schema)
 
-    def write_records_to_output(self, record_list: Iterable, output: BinaryIO):
+    def write_records_to_output(self, record_list: Iterable, output: BinaryIO, output_opts: dict):
 
         self.writer = fastavro.write.Writer(output, self.parsed_base_schema)
 

--- a/RecordMapper/builders/BuiltinFunctions.py
+++ b/RecordMapper/builders/BuiltinFunctions.py
@@ -1,12 +1,14 @@
 """
 This module defines a set of built-in functions.
 """
+from datetime import datetime
+
 
 def copyFrom(path_to_copy_from: str):
     """This built-in function returns the value of 'path_to_copy_from' key.
     """
 
-    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict, is_nested_record: bool=False):
+    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict):
         composed_key = (path_to_copy_from,)
         return record.get(composed_key, None)
 
@@ -17,7 +19,7 @@ def toNull():
     """This returns always null.
     """
 
-    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict, is_nested_record: bool=False):
+    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict):
         return None
 
     return transform_function
@@ -25,27 +27,63 @@ def toNull():
 def toInt():
     """This built-in function casts the current value to Int and returns the result.
     """
+    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict):
+        value_to_return = None
+        if current_value is not None:
+            if str(current_value).isdigit():
+                value_to_return = int(round(float(current_value)))
 
+        return value_to_return
 
-    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict, is_nested_record: bool=False):
-        if current_value is None:
-            return None
-        else:
-            return int(current_value)
-    
     return transform_function
+
 
 def toString():
     """This built-in function casts the current value to String and returns the result.
     """
 
-    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict, is_nested_record: bool=False):
+    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict,
+                           is_nested_record: bool = False):
         if current_value is None:
             return None
         else:
             return str(current_value)
-    
+
     return transform_function
+
+
+def toBool(value_for_true: str):
+    """This built-in function casts the current value to Bool and returns the result.
+    """
+
+    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict,
+                           is_nested_record: bool = False):
+        if current_value is None:
+            return None
+        else:
+            return value_for_true == current_value
+
+    return transform_function
+
+
+def toDate(format: str):
+    """This built-in function casts the current value to Date and returns the result.
+
+    :param format: the passed format which will guide the parser to build the datetime correctly
+    :type format: str
+    """
+
+    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict,
+                           is_nested_record: bool = False):
+        if current_value is None:
+            return None
+        else:
+            date_time_obj = datetime.strptime(current_value, format)
+
+            return str(date_time_obj)
+
+    return transform_function
+
 
 def get_from_custom_variable(variable_name: str):
     """This built-in function gets from custom_variables the value 'variable_name'.
@@ -54,7 +92,7 @@ def get_from_custom_variable(variable_name: str):
     :type variable_name: str
     """
 
-    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict, is_nested_record: bool=False):
+    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict):
         return custom_variables[variable_name]
 
     return transform_function

--- a/RecordMapper/builders/FunctionBuilder.py
+++ b/RecordMapper/builders/FunctionBuilder.py
@@ -5,9 +5,11 @@ import importlib
 
 from RecordMapper.builders import BuiltinFunctions
 
+
 class InvalidFunctionError(Exception):
     """An exception that represents an invalid string reference for a function"""
     pass
+
 
 class FunctionBuilder(object):
     """A Builder class of functions"""
@@ -17,12 +19,11 @@ class FunctionBuilder(object):
         """
         This function parses a string and generates a function to be used as a transform function
         :param function_str: A string that represents a function.
-        "type function_str: str 
+        "type function_str: str
         :return: A transform function.
         :rtype: Callable[[object, dict], object]
         """
-
-        parsed_function = re.match("^([\.\w]+)(?:\(([\w|,]*)\))?$", function_str)
+        parsed_function = re.match("^([\.\w]+)(?:\(([\w|,%\'-: ]*)\))?$", function_str)
         if not parsed_function:
             raise RuntimeError(f"Invalid name for a transform function: '{function_str}'")
 
@@ -30,14 +31,13 @@ class FunctionBuilder(object):
         args_list = str(args).split(",") if (args is not None and args != '') else []
 
         # Check if it is a built-in function
-        builtin_function = FunctionBuilder.get_builtin_function(function_name, args_list) 
+        builtin_function = FunctionBuilder.get_builtin_function(function_name, args_list)
 
         if builtin_function is not None:
             return builtin_function
 
         # Get it as custom function
         return FunctionBuilder.get_custom_function(function_name, args_list)
- 
 
     @staticmethod
     def get_builtin_function(function_name: str, args_list: List[str]) -> Callable[[object, dict], object]:
@@ -52,7 +52,8 @@ class FunctionBuilder(object):
 
         """
         # Check if it is a built-in function
-        possible_function = [obj for name, obj in getmembers(BuiltinFunctions) if name == function_name and isfunction(obj)]
+        possible_function = [obj for name, obj in getmembers(BuiltinFunctions) if
+                             name == function_name and isfunction(obj)]
 
         if len(possible_function) == 1:
             return possible_function[0](*args_list)

--- a/RecordMapper/common/Writer.py
+++ b/RecordMapper/common/Writer.py
@@ -1,4 +1,4 @@
-from typing import BinaryIO,Iterable
+from typing import BinaryIO, Iterable
 
 
 class Writer(object):
@@ -17,7 +17,7 @@ class Writer(object):
 
         self.output_stream = None
 
-    def write_records(self, records: Iterable):
+    def write_records(self, records: Iterable, output_opts: dict):
         """This function writes the records to the output file.
 
         :param records: An iterable of records.
@@ -28,9 +28,9 @@ class Writer(object):
 
         self.output_stream = open(self.file_path, self.write_options)
 
-        return self.write_records_to_output(records, self.output_stream)
+        return self.write_records_to_output(records, self.output_stream, output_opts)
 
-    def write_records_to_output(self, records: Iterable, output: BinaryIO):
+    def write_records_to_output(self, records: Iterable, output: BinaryIO, flatten_csv: bool, output_opts: dict):
         """Write the records to an output file. This function has to be implemented by a
         child class.
 
@@ -48,4 +48,3 @@ class Writer(object):
         """
 
         self.output_stream.close()
-

--- a/RecordMapper/common/Writer.py
+++ b/RecordMapper/common/Writer.py
@@ -30,7 +30,7 @@ class Writer(object):
 
         return self.write_records_to_output(records, self.output_stream, output_opts)
 
-    def write_records_to_output(self, records: Iterable, output: BinaryIO, flatten_csv: bool, output_opts: dict):
+    def write_records_to_output(self, records: Iterable, output: BinaryIO, output_opts: dict):
         """Write the records to an output file. This function has to be implemented by a
         child class.
 

--- a/RecordMapper/csv/CSVWriter.py
+++ b/RecordMapper/csv/CSVWriter.py
@@ -43,20 +43,21 @@ class CSVWriter(Writer):
 
         :param record: A input record.
         :type record: dict
-        :param flatten: Indicates if a dictionary should be writen as regluar fields of the record.
-        :type flatten: boolean
+        :param output_opts: Indicates if a dictionary should be writen as regular fields of the record.
+        :type output_opts: boolean
         :return: A formatted record to be written.
         :rtype: dict
         """
 
         record_to_write = {**record}
-
-        flatten = output_opts["flatten_csv"]
-        excluded_field_from_flattening = output_opts["excluded_fields_from_flattening"]
+        flatten = output_opts["flatten_csv"] if output_opts != None and output_opts["flatten_csv"] else False
+        excluded_fields_from_flattening = output_opts["excluded_fields_from_flattening"] if output_opts != None and \
+                                                                                            output_opts[
+                                                                                                "excluded_fields_from_flattening"] else False
 
         for key, value in record.items():
             if isinstance(value, dict):
-                if not flatten or key in excluded_field_from_flattening:
+                if not flatten or key in excluded_fields_from_flattening:
                     record_to_write[key] = json.dumps(value)
                 else:
                     record_to_write[key] = None

--- a/RecordMapper/csv/CSVWriter.py
+++ b/RecordMapper/csv/CSVWriter.py
@@ -4,6 +4,7 @@ from typing import BinaryIO, List, Iterable
 
 from RecordMapper.common import Writer
 
+
 class CSVWriter(Writer):
     """The object that writes records to a csv file.
     """
@@ -21,7 +22,7 @@ class CSVWriter(Writer):
         super().__init__(file_path)
         self.fieldnames = fieldnames
 
-    def write_records_to_output(self, records: Iterable[dict], output: BinaryIO):
+    def write_records_to_output(self, records: Iterable[dict], output: BinaryIO, output_opts: dict):
         """Writes the records to an output file.
 
         :param records: An iterable of records.
@@ -34,22 +35,32 @@ class CSVWriter(Writer):
         csv_writer.writeheader()
 
         for record in records:
-            csv_writer.writerow(self.format_record(record))
-    
-    def format_record(self, record: dict) -> dict:
+            csv_writer.writerow(self.format_record(record, output_opts))
+
+    def format_record(self, record: dict, output_opts: dict) -> dict:
         """Format a record to be written. For example, dicts will be serialized to
         JSON strings.
 
         :param record: A input record.
         :type record: dict
+        :param flatten: Indicates if a dictionary should be writen as regluar fields of the record.
+        :type flatten: boolean
         :return: A formatted record to be written.
         :rtype: dict
         """
 
         record_to_write = {**record}
 
+        flatten = output_opts["flatten_csv"]
+        excluded_field_from_flattening = output_opts["excluded_fields_from_flattening"]
+
         for key, value in record.items():
             if isinstance(value, dict):
-                record_to_write[key] = json.dumps(value)
+                if not flatten or key in excluded_field_from_flattening:
+                    record_to_write[key] = json.dumps(value)
+                else:
+                    record_to_write[key] = None
+                    for key2 in value:
+                        record_to_write[key2] = value[key2]
 
         return record_to_write

--- a/RecordMapper/csv/CSVWriter.py
+++ b/RecordMapper/csv/CSVWriter.py
@@ -43,25 +43,22 @@ class CSVWriter(Writer):
 
         :param record: A input record.
         :type record: dict
-        :param output_opts: Indicates if a dictionary should be writen as regular fields of the record.
-        :type output_opts: boolean
+        :param flatten: Indicates if a dictionary should be writen as regluar fields of the record.
+        :type flatten: boolean
         :return: A formatted record to be written.
         :rtype: dict
         """
 
         record_to_write = {**record}
-        flatten = output_opts["flatten_csv"] if output_opts != None and output_opts["flatten_csv"] else False
-        excluded_fields_from_flattening = output_opts["excluded_fields_from_flattening"] if output_opts != None and \
-                                                                                            output_opts[
-                                                                                                "excluded_fields_from_flattening"] else False
+
+        fields_to_flat = list(output_opts.get("flat_nested_schema_on_csv", dict()).keys())
 
         for key, value in record.items():
             if isinstance(value, dict):
-                if not flatten or key in excluded_fields_from_flattening:
-                    record_to_write[key] = json.dumps(value)
+                if key in fields_to_flat:
+                    record_to_write = {**record_to_write, **value}
+                    del record_to_write[key]
                 else:
-                    record_to_write[key] = None
-                    for key2 in value:
-                        record_to_write[key2] = value[key2]
+                    record_to_write[key] = json.dumps(value)
 
         return record_to_write

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import setuptools
-from os import path
 
 DEPENDENCIES = [
     'coverage==4.5.4',

--- a/tests/appliers/test_NestedSchemaSelectorApplier.py
+++ b/tests/appliers/test_NestedSchemaSelectorApplier.py
@@ -9,7 +9,7 @@ class test_NestedSchemaSelectorApplier(unittest.TestCase):
     def test_apply(self):
         
         # Arrange
-        def test_selector(key, record):
+        def test_selector(key, record, custom_fields):
 
             return "NestSchema1"
 
@@ -29,8 +29,8 @@ class test_NestedSchemaSelectorApplier(unittest.TestCase):
         test_input_record = {("field_1",): "hola"}
 
         # Act
-
-        res_record, res_complete_flat_schema = NestedSchemaSelectorApplier(test_flat_schemas, {}).apply(test_input_record, test_flat_schemas["base_schema"])
+        ne = NestedSchemaSelectorApplier(test_flat_schemas, {})
+        res_record, res_complete_flat_schema = ne.apply(test_input_record, test_flat_schemas["base_schema"])
 
         # Assert
         self.assertDictEqual(res_record, test_input_record) # Without changes
@@ -40,7 +40,7 @@ class test_NestedSchemaSelectorApplier(unittest.TestCase):
     def test_apply_with_null_result_on_select(self):
 
         # Arrange
-        def test_selector(key, record):
+        def test_selector(key, record, custom_fields):
 
             return None
 

--- a/tests/appliers/test_NestedSchemaSelectorApplier.py
+++ b/tests/appliers/test_NestedSchemaSelectorApplier.py
@@ -9,7 +9,7 @@ class test_NestedSchemaSelectorApplier(unittest.TestCase):
     def test_apply(self):
         
         # Arrange
-        def test_selector(key, record, custom_fields):
+        def test_selector(key, record):
 
             return "NestSchema1"
 
@@ -40,7 +40,7 @@ class test_NestedSchemaSelectorApplier(unittest.TestCase):
     def test_apply_with_null_result_on_select(self):
 
         # Arrange
-        def test_selector(key, record, custom_fields):
+        def test_selector(key, record):
 
             return None
 

--- a/tests/avro/test_avro_classes.py
+++ b/tests/avro/test_avro_classes.py
@@ -2,8 +2,6 @@ import unittest
 import tempfile
 import os
 
-import fastavro
-
 from RecordMapper.avro import AvroWriter
 from RecordMapper.avro import AvroReader
 
@@ -40,7 +38,8 @@ class test_AvroWriter(unittest.TestCase):
         temp_file = tempfile.NamedTemporaryFile("w", delete=False)
 
         writer = AvroWriter(temp_file.name, test_schema)
-        writer.write_records(test_records) 
+        output_opts = {}
+        writer.write_records(test_records, output_opts)
         writer.close()
 
         reader = AvroReader(temp_file.name)
@@ -94,6 +93,7 @@ class test_AvroWriter(unittest.TestCase):
                 "field_4": 5,
                 "field_with_nested_schema":{
                     "nested_field_1": 5
+
                 }
             }
         ]
@@ -130,7 +130,8 @@ class test_AvroWriter(unittest.TestCase):
         temp_file = tempfile.NamedTemporaryFile("w", delete=False)
 
         writer = AvroWriter(temp_file.name, test_schema, [test_nested_schema])
-        writer.write_records(test_records) 
+        output_opts = {"merge_schemas": True}
+        writer.write_records(test_records, output_opts)
         writer.close()
 
         reader = AvroReader(temp_file.name)

--- a/tests/csv/test_csv_classes.py
+++ b/tests/csv/test_csv_classes.py
@@ -22,7 +22,8 @@ class test_AvroWriter(unittest.TestCase):
         temp_file = tempfile.NamedTemporaryFile("w", delete=False)
 
         writer = CSVWriter(temp_file.name, fieldnames=["field_1", "field_2", "field_3", "field_4"])
-        writer.write_records(test_records) 
+        output_opts = {}
+        writer.write_records(test_records, output_opts)
         writer.close()
 
         reader = CSVReader(temp_file.name)

--- a/tests/test_RecordMapper.py
+++ b/tests/test_RecordMapper.py
@@ -1,6 +1,6 @@
-import unittest
 import os
 import tempfile
+import unittest
 
 from RecordMapper import RecordMapper
 from RecordMapper.avro.AvroReader import AvroReader
@@ -10,22 +10,21 @@ from RecordMapper.csv.CSVReader import CSVReader
 class test_RecordMapper(unittest.TestCase):
 
     def test_transform_record(self):
-
         # Arrange
         test_schema = {
             "type": "record",
             "name": "TestSchema",
             "fields": [
-               {"name": "field_1", "type": "string", "aliases": ["another_field"]},
-               {"name": "field_2", "aliases": ["field_auxiliar"], "type": ["int", "null"]},
-               {"name": "field_3", "type": ["string", "null"]},
-               {"name": "field_4", "type": "int", "transform": ["copyFrom(field_2)"]},
-               {"name": "field_5", "type": "int", "transform": ["copyFrom(field_2)", "toNull"]}
+                {"name": "field_1", "type": "string", "aliases": ["another_field"]},
+                {"name": "field_2", "aliases": ["field_auxiliar"], "type": ["int", "null"]},
+                {"name": "field_3", "type": ["string", "null"]},
+                {"name": "field_4", "type": "int", "transform": ["copyFrom(field_2)"]},
+                {"name": "field_5", "type": "int", "transform": ["copyFrom(field_2)", "toNull"]}
             ]
         }
 
         input_record = {
-            "field_auxiliar" : 21
+            "field_auxiliar": 21
         }
 
         expected_record = {
@@ -39,31 +38,31 @@ class test_RecordMapper(unittest.TestCase):
         self.assertDictEqual(res_record, expected_record)
 
     def test_transform_record(self):
-
         # Arrange
         test_schema = {
             "type": "record",
             "name": "TestSchema",
             "fields": [
-               {"name": "field_1", "type": "string", "aliases": ["another_field"]},
-               {"name": "field_2", "aliases": ["field_auxiliar"], "type": ["int", "null"]},
-               {"name": "field_3", "type": ["string", "null"]},
-               {"name": "field_4", "type": "int", "transform": ["copyFrom(field_2)"]},
-               {"name": "field_5", "type": ["TestNestedSchema"], "nestedSchemaSelector": "tests.custom_functions_for_tests.selectSchema(TestNestedSchema)"}
+                {"name": "field_1", "type": "string", "aliases": ["another_field"]},
+                {"name": "field_2", "aliases": ["field_auxiliar"], "type": ["int", "null"]},
+                {"name": "field_3", "type": ["string", "null"]},
+                {"name": "field_4", "type": "int", "transform": ["copyFrom(field_2)"]},
+                {"name": "field_5", "type": ["TestNestedSchema"],
+                 "nestedSchemaSelector": "tests.custom_functions_for_tests.selectSchema(TestNestedSchema)"}
             ]
         }
 
-        test_nested_schema =  {
+        test_nested_schema = {
             "type": "record",
             "name": "TestNestedSchema",
             "fields": [
-               {"name": "nested_field_1", "type": "string"},
-               {"name": "nested_field_2", "type": ["string", "null"], "transform": "copyFrom(field_3)"}
+                {"name": "nested_field_1", "type": "string"},
+                {"name": "nested_field_2", "type": ["string", "null"], "transform": "copyFrom(field_3)"}
             ]
         }
 
         input_record = {
-            "field_auxiliar" : 21,
+            "field_auxiliar": 21,
             "field_3": "hola"
         }
 
@@ -81,24 +80,23 @@ class test_RecordMapper(unittest.TestCase):
         self.assertDictEqual(res_record, expected_record)
 
     def test_write_with_schemas_for_write(self):
-
-       # Arrange
+        # Arrange
         test_schema = {
             "type": "record",
             "name": "TestSchema",
             "fields": [
-               {"name": "field_1", "type": ["string", "null"]},
-               {"name": "field_2", "type": ["int", "null"]},
-               {"name": "field_3", "type": ["TestNestedSchema", "null"]},
+                {"name": "field_1", "type": ["string", "null"]},
+                {"name": "field_2", "type": ["int", "null"]},
+                {"name": "field_3", "type": ["TestNestedSchema", "null"]},
             ]
         }
 
-        test_nested_schema =  {
+        test_nested_schema = {
             "type": "record",
             "name": "TestNestedSchema",
             "fields": [
-               {"name": "nested_field_1", "type": ["string", "null"]},
-               {"name": "nested_field_2", "type": ["string", "null"]}
+                {"name": "nested_field_1", "type": ["string", "null"]},
+                {"name": "nested_field_2", "type": ["string", "null"]}
             ]
         }
 
@@ -106,18 +104,18 @@ class test_RecordMapper(unittest.TestCase):
             "type": "record",
             "name": "TestSchema",
             "fields": [
-               {"name": "field_1", "type": ["string", "null"]},
-               {"name": "field_3", "type": ["TestNestedSchema", "null"]},
+                {"name": "field_1", "type": ["string", "null"]},
+                {"name": "field_3", "type": ["TestNestedSchema", "null"]},
             ]
         }
 
-        test_nested_schema_for_write =  {
+        test_nested_schema_for_write = {
             "type": "record",
             "name": "TestNestedSchema",
             "fields": [
-               {"name": "nested_field_1", "type": ["string", "null"]},
-               {"name": "nested_field_2", "type": ["string", "null"]},
-               {"name": "nested_field_3", "type": ["string", "null"]}
+                {"name": "nested_field_1", "type": ["string", "null"]},
+                {"name": "nested_field_2", "type": ["string", "null"]},
+                {"name": "nested_field_3", "type": ["string", "null"]}
             ]
         }
 
@@ -139,7 +137,6 @@ class test_RecordMapper(unittest.TestCase):
                 }
             }
         ]
-
 
         expected_records = [
             {
@@ -164,8 +161,8 @@ class test_RecordMapper(unittest.TestCase):
         avro_temp_file = tempfile.NamedTemporaryFile(delete=False)
 
         record_mapper = RecordMapper(test_schema, [test_nested_schema])
-        
-        record_mapper.write_records(input_records,{
+
+        record_mapper.write_records(input_records, {
             "avro": avro_temp_file.name
         }, test_schema_for_write, [test_nested_schema_for_write])
 
@@ -174,31 +171,30 @@ class test_RecordMapper(unittest.TestCase):
         res_records = list(avro_reader.read_records())
         avro_reader.close()
         self.assertListEqual(res_records, expected_records)
- 
+
         os.remove(avro_temp_file.name)
 
-    
     def test_execute_from_csv(self):
-
         # Arrange
         test_schema = {
             "type": "record",
             "name": "TestSchema",
             "fields": [
-               {"name": "field_1", "type": ["string", "null"], "aliases": ["another_field"]},
-               {"name": "field_2", "aliases": ["field_auxiliar"], "type": ["int", "null"], "transform": "toInt"},
-               {"name": "field_3", "type": ["string", "null"]},
-               {"name": "field_4", "type": "int", "transform": ["copyFrom(field_2)", "toInt"]},
-               {"name": "field_5", "type": "TestNestedSchema", "nestedSchemaSelector": "tests.custom_functions_for_tests.selectSchema(TestNestedSchema)"}
+                {"name": "field_1", "type": ["string", "null"], "aliases": ["another_field"]},
+                {"name": "field_2", "aliases": ["field_auxiliar"], "type": ["int", "null"], "transform": "toInt"},
+                {"name": "field_3", "type": ["string", "null"]},
+                {"name": "field_4", "type": "int", "transform": ["copyFrom(field_2)", "toInt"]},
+                {"name": "field_5", "type": "TestNestedSchema",
+                 "nestedSchemaSelector": "tests.custom_functions_for_tests.selectSchema(TestNestedSchema)"}
             ]
         }
 
-        test_nested_schema =  {
+        test_nested_schema = {
             "type": "record",
             "name": "TestNestedSchema",
             "fields": [
-               {"name": "nested_field_1", "type": ["string", "null"]},
-               {"name": "nested_field_2", "type": ["string", "null"], "transform": "copyFrom(field_3)"}
+                {"name": "nested_field_1", "type": ["string", "null"]},
+                {"name": "nested_field_2", "type": ["string", "null"], "transform": "copyFrom(field_3)"}
             ]
         }
 
@@ -227,14 +223,14 @@ class test_RecordMapper(unittest.TestCase):
 
         expected_csv_records = [
             {
-                "field_1" : None,
+                "field_1": None,
                 "field_2": '21',
                 "field_3": "example_1",
                 "field_4": '21',
                 "field_5": """{"nested_field_1": null, "nested_field_2": "example_1"}"""
             },
             {
-                "field_1" : None,
+                "field_1": None,
                 "field_2": '54',
                 "field_3": "example_2",
                 "field_4": '54',
@@ -246,22 +242,113 @@ class test_RecordMapper(unittest.TestCase):
         csv_temp_file = tempfile.NamedTemporaryFile(delete=False)
 
         record_mapper = RecordMapper(test_schema, [test_nested_schema])
-        
+
         record_mapper.execute("csv", "files/test_1.csv", {
             "avro": avro_temp_file.name,
-            "csv": csv_temp_file.name },
-            output_opts={
-                "flat_nested_schema_on_csv": {'field_5': "test_nested_schema"},
-                "merge_schemas": True
-            }
-        )
+            "csv": csv_temp_file.name},
+                              output_opts={
+                                  "flat_nested_schema_on_csv": {},
+                                  "merge_schemas": True
+                              }
+                              )
 
         # Assert
         avro_reader = AvroReader(avro_temp_file.name)
         avro_records = list(avro_reader.read_records())
         avro_reader.close()
         self.assertListEqual(avro_records, expected_avro_records)
-        
+
+        csv_reader = CSVReader(csv_temp_file.name)
+        csv_records = list(csv_reader.read_records())
+        csv_reader.close()
+        self.assertListEqual([dict(x) for x in csv_records], expected_csv_records)
+
+        os.remove(avro_temp_file.name)
+        os.remove(csv_temp_file.name)
+
+    def test_execute_from_csv_and_flat(self):
+        # Arrange
+        test_schema = {
+            "type": "record",
+            "name": "TestSchema",
+            "fields": [
+                {"name": "field_1", "type": ["string", "null"], "aliases": ["another_field"]},
+                {"name": "field_2", "aliases": ["field_auxiliar"], "type": ["int", "null"], "transform": "toInt"},
+                {"name": "field_3", "type": ["string", "null"]},
+                {"name": "field_4", "type": "int", "transform": ["copyFrom(field_2)", "toInt"]},
+                {"name": "field_5", "type": "TestNestedSchema",
+                 "nestedSchemaSelector": "tests.custom_functions_for_tests.selectSchema(TestNestedSchema)"}
+            ]
+        }
+
+        test_nested_schema = {
+            "type": "record",
+            "name": "TestNestedSchema",
+            "fields": [
+                {"name": "nested_field_1", "type": ["string", "null"]},
+                {"name": "nested_field_2", "type": ["string", "null"], "transform": "copyFrom(field_3)"}
+            ]
+        }
+
+        expected_avro_records = [
+            {
+                "field_1": None,
+                "field_2": 21,
+                "field_3": "example_1",
+                "field_4": 21,
+                "field_5": {
+                    "nested_field_1": None,
+                    "nested_field_2": "example_1"
+                }
+            },
+            {
+                "field_1": None,
+                "field_2": 54,
+                "field_3": "example_2",
+                "field_4": 54,
+                "field_5": {
+                    "nested_field_1": None,
+                    "nested_field_2": "example_2"
+                }
+            },
+        ]
+
+        expected_csv_records = [
+            {
+                "field_1": None,
+                "field_2": '21',
+                "field_3": "example_1",
+                "field_4": '21',
+                "field_5": None,
+                "nested_field_1": None,
+                "nested_field_2": "example_1"
+            },
+            {
+                "field_1": None,
+                "field_2": '54',
+                "field_3": "example_2",
+                "field_4": '54',
+                "field_5": None,
+                "nested_field_1": None,
+                "nested_field_2": "example_2"
+            }
+        ]
+        # Act
+        avro_temp_file = tempfile.NamedTemporaryFile(delete=False)
+        csv_temp_file = tempfile.NamedTemporaryFile(delete=False)
+
+        record_mapper = RecordMapper(test_schema, [test_nested_schema])
+
+        record_mapper.execute("csv", "files/test_1.csv", {
+            "avro": avro_temp_file.name,
+            "csv": csv_temp_file.name},
+                output_opts={
+                  "flat_nested_schema_on_csv": {"field_5": "TestNestedSchema"},
+                  "merge_schemas": True
+                }
+        )
+
+        # Assert
         csv_reader = CSVReader(csv_temp_file.name)
         csv_records = list(csv_reader.read_records())
         csv_reader.close()

--- a/tests/test_RecordMapper.py
+++ b/tests/test_RecordMapper.py
@@ -75,8 +75,8 @@ class test_RecordMapper(unittest.TestCase):
                 "nested_field_2": "hola"
             }
         }
-
-        res_record = RecordMapper(test_schema, [test_nested_schema]).transform_record(input_record)
+        recordMapper = RecordMapper(test_schema, [test_nested_schema])
+        res_record = recordMapper.transform_record(input_record)
 
         self.assertDictEqual(res_record, expected_record)
 
@@ -247,10 +247,14 @@ class test_RecordMapper(unittest.TestCase):
 
         record_mapper = RecordMapper(test_schema, [test_nested_schema])
         
-        record_mapper.execute("csv", "tests/files/test_1.csv", {
+        record_mapper.execute("csv", "files/test_1.csv", {
             "avro": avro_temp_file.name,
-            "csv": csv_temp_file.name 
-        })
+            "csv": csv_temp_file.name },
+            output_opts={
+                "flat_nested_schema_on_csv": {'field_5': "test_nested_schema"},
+                "merge_schemas": True
+            }
+        )
 
         # Assert
         avro_reader = AvroReader(avro_temp_file.name)


### PR DESCRIPTION
Now the code is able to select if the output csv must be flatten or not and in that case, the fields that must be flatten. That is passed when the output_opts dict is passed to the RecordMapper.execute method. Something like this:

           output_opts={
                "flat_nested_schema_on_csv": {'field__of_base_schema_to_be_flattened': "name_of_the_nested_schema"},
                "merge_schemas": True
            }

The merge_schemas value represents if the avro output schema must be merged as in the record mapper output schemas, the nested ones must be out of the base one and not expanded on every field type that represent a nested schema.

In addition, now the custom_fields is passed to the custom functions and that way they are more flexible.

Some built in functions have been added like toBool and toInt. 