### PR TITLE
fixed tests and fixed toInt function

### DIFF
--- a/RecordMapper/builders/BuiltinFunctions.py
+++ b/RecordMapper/builders/BuiltinFunctions.py
@@ -40,7 +40,8 @@ def toInt():
 
         if current_value is not None:
             try:
-                float_current_value = float(current_value)
+                clean_current_value = current_value.replace(",", ".")
+                float_current_value = float(clean_current_value)
                 value_to_return = int(math.floor(float_current_value))
             except:
                 value_to_return = None

--- a/tests/test_RecordMapper.py
+++ b/tests/test_RecordMapper.py
@@ -326,7 +326,6 @@ class test_RecordMapper(unittest.TestCase):
                 "field_2": '21',
                 "field_3": "example_1",
                 "field_4": '21',
-                "field_5": None,
                 "nested_field_1": None,
                 "nested_field_2": "example_1"
             },
@@ -335,7 +334,6 @@ class test_RecordMapper(unittest.TestCase):
                 "field_2": '54',
                 "field_3": "example_2",
                 "field_4": '54',
-                "field_5": None,
                 "nested_field_1": None,
                 "nested_field_2": "example_2"
             }


### PR DESCRIPTION
Numbers like "1500,3" throw an exception. So, I have added a "replace" from "," to "." to avoid errors.