### PR TITLE
Add null functions to schema and record transformations

### DIFF
--- a/RecordMapper/builders/FunctionBuilder.py
+++ b/RecordMapper/builders/FunctionBuilder.py
@@ -1,5 +1,5 @@
 import re
-from typing import Callable, List
+from typing import Callable, List, Union
 from inspect import getmembers, isfunction
 import importlib
 
@@ -15,14 +15,19 @@ class FunctionBuilder(object):
     """A Builder class of functions"""
 
     @staticmethod
-    def parse_function_str(function_str: str) -> Callable[[object, dict], object]:
+    def parse_function_str(function_str: str) -> Union[Callable[[object, dict], object], None]:
         """
-        This function parses a string and generates a function to be used as a transform function
+        This function parses a string and generates a function to be used as a transform function.
+        If function_str is None, it returns None.
         :param function_str: A string that represents a function.
         "type function_str: str
         :return: A transform function.
-        :rtype: Callable[[object, dict], object]
+        :rtype: Union[Callable[[object, dict], object], None]
         """
+
+        if function_str is None:
+            return None
+
         parsed_function = re.match("^([\.\w]+)(?:\(([\w|,%\'-: ]*)\))?$", function_str)
         if not parsed_function:
             raise RuntimeError(f"Invalid name for a transform function: '{function_str}'")

--- a/tests/appliers/test_TransformApplier.py
+++ b/tests/appliers/test_TransformApplier.py
@@ -102,6 +102,47 @@ class test_TransformApplier(unittest.TestCase):
         self.assertDictEqual(res_record, expected_record)
         self.assertDictEqual(res_schema, test_schema)
 
+    def test_record_transform_function(self):
+
+        test_schema = {
+            ("field_1", ) : FieldData(["string"], [], [], None),
+            ("field_2", ) : FieldData(["int"], [], [None, copyFrom("field_3"), custom_functions_for_tests.collapse_values("field_2", "collapse_dict")], None),
+            ("field_3", ) : FieldData(["int"], [], [], None),
+            ("field_4", ) : FieldData(["int"], [], [], None),
+            ("field_5", ) : FieldData(["int"], [], [custom_functions_for_tests.collapse_values("field_5", "collapse_dict")], None),
+            ("field_6", ) : FieldData(["int"], [], [], None)
+        }
+
+        input_record = {
+            ("field_1",): "hola",
+            ("field_2",): 56,
+            ("field_3",): 7,
+            ("field_4",): 78,
+            ("field_6",): 12
+        }
+
+        expected_record = {
+            ("field_1",): "hola",
+            ("field_2",): None,
+            ("field_3",): 7,
+            ("field_4",): 78,
+            ("field_5",): None,
+            ("field_6",): 12,
+            ("collapse_dict",): {
+                "field_2": 7,
+                "field_5": None
+            }
+        }
+
+        # Act
+        res_record, res_schema = TransformApplier({}).apply(input_record, test_schema)
+
+        print("res_record:", res_record)
+        
+        # Assert
+        self.assertDictEqual(res_record, expected_record)
+        self.assertDictEqual(res_schema, test_schema)
+
     def test_transform_with_nested_schemas(self):
         # Arrange
         test_schema = {

--- a/tests/builders/test_FlatSchemaBuilder.py
+++ b/tests/builders/test_FlatSchemaBuilder.py
@@ -37,6 +37,32 @@ class test_FlatSchemaBuilder(unittest.TestCase):
 
         # Assert
         self.assertTrue("Invalid module for a custom function" in str(context.exception))
+
+    def test_get_transform_function_with_null_value(self):
+
+        # Arrange
+        test_type_field = [None]
+
+        # Act
+        res = FlatSchemaBuilder.get_transform_functions_from_field(test_type_field)
+
+        # Assert
+        self.assertEqual(len(res), 1)
+        self.assertTrue(res[0] is None)
+
+    def test_get_transform_function_from_field_in_list_format_with_null_values(self):
+
+        # Arrange
+        test_type_field = [None, "copyFrom(field_x)", None]
+
+        # Act
+        res = FlatSchemaBuilder.get_transform_functions_from_field(test_type_field)
+
+        # Assert
+        self.assertEqual(len(res), 3)
+        self.assertTrue(res[0] is None)
+        self.assertTrue(res[1] is not None)
+        self.assertTrue(res[2] is None)
     
     def test_get_selector_function(self):
 
@@ -67,7 +93,8 @@ class test_FlatSchemaBuilder(unittest.TestCase):
                {"name": "field_2", "type": ["int", "null"]},
                {"name": "field_3", "type": ["Schema1", "Schema2"], "nestedSchemaSelector": "toNull"},
                {"name": "field_4", "type": "int", "transform": ["copyFrom(field_2)"]},
-               {"name": "field_5", "type": "int", "transform": ["copyFrom(field_2)", "toNull"]}
+               {"name": "field_5", "type": "int", "transform": ["copyFrom(field_2)", "toNull"]},
+               {"name": "field_6", "type": "int", "transform": [None, "copyFrom(field_2)", "toNull"]},
             ]
         }
 
@@ -86,6 +113,7 @@ class test_FlatSchemaBuilder(unittest.TestCase):
             (("field_2",), ["int", "null"], [], 0, False),
             (("field_3",), ["Schema1", "Schema2"], [], 0, True),
             (("field_4",), ["int"], [], 1, False),
-            (("field_5",), ["int"], [], 2, False)
+            (("field_5",), ["int"], [], 2, False),
+            (("field_6",), ["int"], [], 3, False)
         ])
 

--- a/tests/custom_functions_for_tests.py
+++ b/tests/custom_functions_for_tests.py
@@ -8,6 +8,21 @@ def sum(number_str: str):
 
     return transform_function
 
+def collapse_values(current_field_name: str, target_dict_name: str):
+    """Add the current field value to a dict. Changes the current value to None"""
+
+    def transform_function(current_value: object, record: dict, complete_transform_schema: dict, custom_variables: dict, is_nested_record: bool=False):
+
+        additional_values = {}
+        target_dict = record.get((target_dict_name,), {})
+
+        target_dict[current_field_name] = current_value
+        additional_values[(target_dict_name,)] = target_dict
+
+        return None, additional_values
+
+    return transform_function
+
 def selectSchema(schema_str: str):
 
     def selectFunction(key, record, custom_variables):


### PR DESCRIPTION
* Now schemas can define "null" functions in transform field.
* Transform functions can return a tuple: The first value works as usually. The second one must be a dict and it will be used to update the final record. This feature is for some cases where a transform function has to modify several values, but this feature is very risky (it can produce weird transformations if it is used intensively) so it has to be used very responsible.