### PR TITLE
Xxxx - Reviewing record mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,26 @@ with the correspondent Writer sub-class (we will be talking about it soon).
 
 
 ## Writers
+
+After applying the record transformations, the Record Mapper must be able to write the
+resultant transformed records in a file. It supports writing files for different formats, 
+including csv and avro. 
+
+Important! The Record Mapper can return different files as output, one for each format, 
+but at least it is mandatory to write the avro file. Thus, avro file is always returned.
+
+The writing process is done by the *Writer* objects. A Writer class implements methods to 
+write to different formats. The Writer class is extended by sub-classes, each of them 
+specialized in writing an specific format. For example, to write a CSV file we can use the
+CSVWriter class while we will be using the AvroWriter to write an Avro file.
+
+A Writer sub-class implements the *write_records_to_output* method, which will write a given
+iterable of records in an output file. The method accepts other output options as parameters.
+These output options include:
+- Flattening nested schemas when writing csv files.
+- Merging schemas when writing avro files.
+
+<TODO: Review this.>
+
+Each specific Writer sub-class is located in the directory of its own format, sharing space
+with the correspondent Reader sub-class.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,47 @@
 # RecordMapper
-Read, transform and write records using an Avro Schema and custom map functions.
+
+Read, transform and write records using an Avro schema and custom map functions.
+
 
 ## Installing the project
 
-To install the project, move to the root directory and run the following command:
+To install the project, run the following command from the root directory:
 
 ```bash
 $pip install .
 ```
 
-It is highly recommended to use a virtual environment when installing the project dependencies.
+It is highly recommended to use a virtual environment when installing the project 
+dependencies in order to avoid version conflicts.
 
-## Update PyPI version
+
+## Updating PyPI version
 
     poetry publish --build
  
-## Appliers
+ 
+## RecordMapper elements
+ 
+### Appliers
 
-## Readers
+Appliers are the elements that materialise the records transformations. They apply 
+sequentially specific transformations to each record and/or its schema. 
 
-To apply the record transformations, the Record Mapper must be able to read the file that
+There are four appliers defined by now:
+
+- The selector applier, which will modify the base schema if there exist nested schemas to consider.
+- The rename applier, which will develop a renaming process using the aliases included in the schema.
+- The transform applier which will apply the record transformations given the transforming functions.
+- The clean applier, which will filter the output fields to keep only the ones given in the output schema.
+
+An Applier is a class that implements the *apply* method, which receives a single 
+record and its schema and returns their transformed version after the transforming
+process. They are located in the appliers directory.
+
+
+### Readers
+
+To apply the records transformations, the Record Mapper must be able to read the file that
 contains the data in order to extract them. The Record Mapper supports reading files from 
 different formats, including csv, xml and avro.
 
@@ -29,15 +51,13 @@ specialized in reading an specific format. For example, to read an XML file we c
 XMLReader class. To extract data from a CSV file, we will be using the CSVReader class.
 
 A Reader sub-class implements the *read_records_from_input* method, which will return the
-content of the file **record by record**.
-
-Each specific Reader sub-class is located in the directory of its own format, sharing space
-with the correspondent Writer sub-class (we will be talking about it soon).
+content of the file record by record. Each specific Reader sub-class is located in the 
+directory of its own format, sharing space with the correspondent Writer sub-class.
 
 
-## Writers
+### Writers
 
-After applying the record transformations, the Record Mapper must be able to write the
+After applying the records transformations, the Record Mapper must be able to write the
 resultant transformed records in a file. It supports writing files for different formats, 
 including csv and avro. 
 
@@ -50,12 +70,8 @@ specialized in writing an specific format. For example, to write a CSV file we c
 CSVWriter class while we will be using the AvroWriter to write an Avro file.
 
 A Writer sub-class implements the *write_records_to_output* method, which will write a given
-iterable of records in an output file. The method accepts other output options as parameters.
-These output options include:
+iterable of records in an output file. Each specific Writer sub-class is located in the 
+directory of its own format, sharing space with the correspondent Reader sub-class. The 
+method accepts other output options as parameters. These output options include:
 - Flattening nested schemas when writing csv files.
 - Merging schemas when writing avro files.
-
-<TODO: Review this.>
-
-Each specific Writer sub-class is located in the directory of its own format, sharing space
-with the correspondent Reader sub-class.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,38 @@
 # RecordMapper
 Read, transform and write records using an Avro Schema and custom map functions.
 
+## Installing the project
+
+To install the project, move to the root directory and run the following command:
+
+```bash
+$pip install .
+```
+
+It is highly recommended to use a virtual environment when installing the project dependencies.
+
 ## Update PyPI version
 
     poetry publish --build
+ 
+## Appliers
+
+## Readers
+
+To apply the record transformations, the Record Mapper must be able to read the file that
+contains the data in order to extract them. The Record Mapper supports reading files from 
+different formats, including csv, xml and avro.
+
+The reading process is done by the *Reader* objects. A Reader class implements methods to 
+read different kind of files. The Reader class is extended by sub-classes, each of them 
+specialized in reading an specific format. For example, to read an XML file we can use the
+XMLReader class. To extract data from a CSV file, we will be using the CSVReader class.
+
+A Reader sub-class implements the *read_records_from_input* method, which will return the
+content of the file **record by record**.
+
+Each specific Reader sub-class is located in the directory of its own format, sharing space
+with the correspondent Writer sub-class (we will be talking about it soon).
+
+
+## Writers

--- a/RecordMapper/RecordMapper.py
+++ b/RecordMapper/RecordMapper.py
@@ -12,25 +12,30 @@ from RecordMapper.utils import chain_functions
 
 
 class RecordMapper(object):
-    """The main class of this package. It has methods to transform data using an Avro Schema (and custom functions).
+    """The main class of this package.
+
+    Include methods to transform data using an Avro Schema and custom functions.
     """
 
     def __init__(self, base_schema: dict, nested_schemas: List[dict] = [], custom_variables: dict = {}):
-        """__init__ function of RecordMapper.
+        """Constructor method of RecordMapper.
 
         :param base_schema: The base schema in avro format to transform the records.
         :type base_schema: dict
         :param nested_schemas: The schemas of the nested record types. Defaults to [].
         :type nested_schemas: List[dict], optional
-        :param custom_variables: A dict of custom variables that will be accesible for the appliers.
+        :param custom_variables: A dict of custom variables that will be accessible for the appliers.
         """
+
+        # Load the base and nested schemas, and the custom variables.
         self.original_base_schema = base_schema
         self.original_nested_schemas = nested_schemas
         self.custom_variables = custom_variables
 
-        # Stats of the record mapper
+        # Initialize the stats of the Record Mapper.
         self.stats = {}
 
+        # Load flatten schemas for both, the base and the nested schemas.
         self.flat_schemas = dict(
             [
                 (schema["name"], FlatSchemaBuilder.get_flat_schema(schema))
@@ -38,40 +43,49 @@ class RecordMapper(object):
             ]
         )
 
+        # Load the appliers.
         self.selector_applier = NestedSchemaSelectorApplier(self.flat_schemas, self.custom_variables)
         self.rename_applier = RenameApplier(self.custom_variables)
         self.transform_applier = TransformApplier(self.custom_variables)
         self.clean_applier = CleanApplier(self.custom_variables)
 
-    def execute(self, input_format: str, input_file_path: str, paths_to_write: dict,
-                input_opts: dict = {}, base_schema_to_write: dict = None, nested_schemas_to_write: List[dict] = None,
+    def execute(self, input_format: str, input_file_path: str, paths_to_write: dict, input_opts: dict = {},
+                base_schema_to_write: dict = None, nested_schemas_to_write: List[dict] = None,
                 output_opts: dict = {}):
-        """Process that reads, transforms a writes the data from a format to another one.
+        """Read, transform and write the data from a format to another one.
 
-        :param input_format: The input format (csv, avro, ...)
+        The following input formats are allowed to be read: csv, avro, xml
+        The following output formats are allowed to be written: csv, avro
+
+        :param input_format: The input format (csv, avro, xml)
         :type input_format: str
         :param input_file_path: The path of the input file.
         :type input_file_path: str
-        :param paths_to_write: A dict with the output formats (avro, csv...) and their configuration.
+        :param paths_to_write: A dict with the output formats (avro, csv) and their configuration.
         :type paths_to_write: dict
-        :param input_opts: Some special options of the input process, defaults to {}
+        :param input_opts: Some special options of the input process. Defaults to {}.
         :type input_opts: dict, optional
-        :param base_schema_to_write: A base schema used to write, defaults to None
+        :param base_schema_to_write: A base schema used to write. Defaults to None.
         :type base_schema_to_write: dict, optional
-        :param nested_schemas_to_write: A list of nested record schemas used to write, defaults to None
+        :param nested_schemas_to_write: A list of nested record schemas used to write. Defaults to None.
         :type nested_schemas_to_write: List[dict], optional
+        :param output_opts: A dict-like set of options to be able to handle the behaviour of the output.
+        :type output_opts: dict
         """
         
-        # Reset stats dict
+        # Reset the stats dictionary.
         self.stats = {}
 
+        # Read, transform and write records.
         read_records = self.read_records(input_format, input_file_path, input_opts)
         transformed_records = self.transform_records(read_records)
-        self.write_records(transformed_records, paths_to_write, base_schema_to_write, nested_schemas_to_write,
-                           output_opts)
+        self.write_records(transformed_records, paths_to_write, base_schema_to_write,
+                           nested_schemas_to_write, output_opts)
 
     def transform_records(self, record_list: Iterable[dict]) -> Iterator[dict]:
-        """A generator of transformed records.
+        """Transform file records using different appliers.
+
+        The method is a generator of transformed records.
 
         :param record_list: An iterable of records.
         :type record_list: Iterable[dict]
@@ -83,7 +97,9 @@ class RecordMapper(object):
             yield self.transform_record(record)
 
     def transform_record(self, record: dict) -> dict:
-        """Apply transforms on a single record. Each transform step is defined in an Applier object.
+        """Apply transformations on a single record.
+
+        Each transform step is defined in an Applier object.
 
         :param record: An input record.
         :type record: dict
@@ -110,13 +126,13 @@ class RecordMapper(object):
         return normal_record
 
     def read_records(self, input_format: str, path_to_read: str, opts: dict = {}) -> Iterator[dict]:
-        """Read records of an input file.
+        """Read records from an input file.
 
         :param input_format: The format of the file.
         :type input_format: str
         :param path_to_read: The path of the file.
         :type path_to_read: str
-        :param opts: Some special options in read process, defaults to {}
+        :param opts: Some special options in the read process. Defaults to {}.
         :type opts: dict, optional
         :raises RuntimeError: [description]
         :return: [description]
@@ -144,30 +160,38 @@ class RecordMapper(object):
 
     def write_records(self, records_list: Iterable, paths_to_write: dict, base_schema_to_write: dict = None,
                       nested_schemas_to_write: List[dict] = None, output_opts: dict = {}):
-        """Writes records to one or several formats. It is necessary to write to an avro file at least.
+        """Write transformed records to one or several formats.
+
+        IMPORTANT NOTE:
+          The Record Mapper is able to write in both, csv and avro formats.
+          But it is always necessary writing an avro file at least.
 
         :param records_list: An iterable of records.
         :type records_list: Iterable
-        :param paths_to_write: A dict with the formats and the paths that will be written. For example, {"csv": "example.csv", "avro": "example.avro"}.
+        :param paths_to_write: A dict with the formats and the paths that will be written.
+            For example, {"csv": "example.csv", "avro": "example.avro"}.
         :type paths_to_write: dict
-        :param base_schema_to_write: A base schema used in the write process different from the one
-            used in the transform process, defaults to None
+        :param base_schema_to_write: A base schema used in the writing process, different
+            from the one used in the transform process. Defaults to None.
         :type base_schema_to_write: dict, optional
-        :param nested_schemas_to_write: A list of nested schemas used in the write process different
-            from the one used in the transform process, defaults to None
+        :param nested_schemas_to_write: A list of nested schemas used in the write process,
+            different from the one used in the transform process. Defaults to None.
         :type nested_schemas_to_write: List[dict], optional
+        :param output_opts: A dict-like set of options to be able to handle the behaviour
+            of the output.
+        :type output_opts: dict, optional
         :raises RuntimeError: Raises and error if there is not a specified path for the avro format.
         """
 
         self.stats["write_count"] = {}
 
-        base_schema_to_write = self.original_base_schema if base_schema_to_write is None else base_schema_to_write
-        nested_schemas_to_write = self.original_nested_schemas if nested_schemas_to_write is None else nested_schemas_to_write
+        base_schema_to_write = self.original_base_schema if not base_schema_to_write else base_schema_to_write
+        nested_schemas_to_write = self.original_nested_schemas if not nested_schemas_to_write else nested_schemas_to_write
 
         if "avro" not in paths_to_write:
-            raise RuntimeError("It is necessary a path to write an Avro File")
+            raise RuntimeError("It is necessary a path to write an Avro File!")
 
-        # Avro writing
+        # Writing the Avro file (mandatory).
         writer_avro = AvroWriter(
             paths_to_write["avro"],
             base_schema_to_write,
@@ -178,8 +202,8 @@ class RecordMapper(object):
         self.stats["write_count"]["avro"] = writer_avro.write_count
         writer_avro.close()
 
+        # Writing the csv file (optional).
         if "csv" in paths_to_write:
-
             fieldnames = [field["name"] for field in base_schema_to_write["fields"]]
 
             ## If we want to consider to flatten the nested schemas:

--- a/RecordMapper/appliers/CleanApplier.py
+++ b/RecordMapper/appliers/CleanApplier.py
@@ -1,12 +1,12 @@
 
 
-
 class CleanApplier(object):
     """An applier that removes the unused files of a record (using a schema as a reference).
     """
 
     def __init__(self, custom_variables: dict):
         """The constructor of the applier.
+
         :param custom_variables: A dict of custom variables.
         :type custom_variables: dict
         """
@@ -14,8 +14,14 @@ class CleanApplier(object):
         self.custom_variables = custom_variables
 
     def apply(self, flat_record: dict, flat_schema: dict) -> (dict, dict):
-        """The apply of the CleanApplier. Removed unused files in a FlatRecord using
-        a FlatSchema as reference (remove the fields that are not in the schema).
+        """Execute the function of this applier.
+
+        Remove unused fields in a FlatRecord using a FlatSchema as
+        reference. The applier only keeps the fields that are in the
+        given schema, filtering the rest.
+
+        As an applier, the output is the transformed record and schema.
+        In CleanApplier, only the record is transformed.
 
         :param flat_record: The input FlatRecord.
         :type flat_record: dict
@@ -27,10 +33,9 @@ class CleanApplier(object):
         
         new_record = {}
 
-        for key, field_data in flat_schema.items():
+        for field_key, field_data in flat_schema.items():
 
-            if key in flat_record:
-                new_record[key] = flat_record[key]
+            if field_key in flat_record:
+                new_record[field_key] = flat_record[field_key]
         
         return new_record, flat_schema
- 

--- a/RecordMapper/appliers/NestedSchemaSelectorApplier.py
+++ b/RecordMapper/appliers/NestedSchemaSelectorApplier.py
@@ -1,9 +1,10 @@
 from typing import Dict
 from RecordMapper.builders.FlatSchemaBuilder import FieldData
 
+
 class NestedSchemaSelectorApplier(object):
     """An applier that modifies a FlatSchema selecting multiple nested schemas using
-       the nestedSchemaSelector function.
+    the nestedSchemaSelector function from a schema field.
     """
 
     def __init__(self, flat_schemas: Dict[str, dict], custom_variables: dict):
@@ -19,35 +20,44 @@ class NestedSchemaSelectorApplier(object):
         self.custom_variables = custom_variables
 
     def apply(self, record: dict, base_flat_schema: dict) -> (dict, dict):
-        """Execute the function of this applier. If a field has several nested schemas as type, this applier
-        creates new base_flat_schema selecting one of the nested schemas (adding their fields to the resulting flat schema)
-        using the function defined in the value "nestedSchemaSelector".
+        """Execute the function of this applier.
+
+        If a field has any nested schemas, this applier creates a new
+        base_flat_schema selecting one of them (adding their fields
+        to the resulting flat schema) using the function defined in
+        the value "nestedSchemaSelector" of a schema field.
+
+        As an applier, the output is the transformed record and schema.
+        In NestedSchemaSelectorApplier, only the schema is transformed.
 
         :param record: The input record. 
         :type record: dict
         :param base_flat_schema: The input base flat schema. 
         :type base_flat_schema: dict. 
-        :return: The record (unmodified) and the flat schema (modified with the selected nested schemas).
+        :return: The record (unmodified) and the flat schema
+            (modified with the selected nested schemas).
         :rtype: (dict, dict)
         """
 
-        # The value that will be returned with the record
+        # The value that will be returned with the record.
         complete_flat_schema = {**base_flat_schema}
 
+        # Look for the fields that include a nested schema selector.
         for field_key, field_data in base_flat_schema.items():
 
             if field_data.selector is not None:
                 complete_flat_schema = self.select_nested_schema_and_add_their_fields(record, complete_flat_schema,
                                                                                       field_key, field_data)
-                # Remove the "super key" to avoid problems
+                # Remove the parent key of the nested schemas from the complete schema.
                 del complete_flat_schema[field_key]
 
-        return (record, complete_flat_schema)
+        return record, complete_flat_schema
 
     def select_nested_schema_and_add_their_fields(self, record: dict, flat_schema: dict, field_key: str,
                                                   field_data: FieldData) -> dict:
-        """Select a nested schema for a field (using the defined function in "selector" value of the FieldData) and add their fields
-        to the resulting flat schema.
+        """Select a nested schema and add their fields to the resulting flat schema.
+
+        It uses the defined function in "selector" value of the FieldData.
 
         :param record: The input record. It will be used as argument
         :type record: dict
@@ -57,19 +67,23 @@ class NestedSchemaSelectorApplier(object):
         :type field_key: str
         :param field_data: The FieldData object of the previous key.
         :type field_data: tuple
-        :raises RuntimeError: This function will raise if the selected nested schema name is not valid. 
+        :raises RuntimeError: This function will raise if the selected nested
+            schema name is not valid.
         :return: The modified flat Schema.
         :rtype: dict
         """
 
+        # Identify the nested schema name.
         nested_schema_name = field_data.selector(field_key, record, self.custom_variables) \
-            if field_data.selector != None and field_data.selector(field_key, record, self.custom_variables) != None else None
+            if (field_data.selector is not None) \
+               and (field_data.selector(field_key, record, self.custom_variables) is not None) \
+            else None
 
-        # Not schema selected (this field will be null)
-        if nested_schema_name == None:
+        # If there is no a nested schema, just skip.
+        if nested_schema_name is None:
             return flat_schema
 
-        # Schema selected. Add their fields to the complete schema
+        # If there is a schema selected, add their fields to the complete schema.
         elif nested_schema_name in self.flat_schemas:
 
             nested_schema = self.flat_schemas[nested_schema_name]
@@ -82,5 +96,6 @@ class NestedSchemaSelectorApplier(object):
             )
 
             return {**flat_schema, **fields_to_add}
+
         else:
             raise RuntimeError(f"Invalid nested schema name: {nested_schema_name}")

--- a/RecordMapper/appliers/RenameApplier.py
+++ b/RecordMapper/appliers/RenameApplier.py
@@ -2,12 +2,15 @@ from typing import List, Union
 
 from collections import namedtuple
 
+
 class RenameApplier(object):
-    """An applier that applies a renaming process using the defined aliases on the schema
-    using the avro convention"""
+    """An applier that applies a renaming process using the defined aliases
+    on the schema using the avro convention.
+    """
 
     def __init__(self, custom_variables: dict):
         """The constructor of the applier.
+
         :param custom_variables: A dict of custom variables.
         :type custom_variables: dict
         """
@@ -15,12 +18,21 @@ class RenameApplier(object):
         self.custom_variables = custom_variables
 
     def apply(self, flat_record: dict, flat_schema: dict) -> (dict, dict):
-        """Executes the function of this applier. It renames the fields of the input record
-        using the "aliases" value of each field and following the Avro convention.
-        IMPORTANT: The "rename process" creates new fields, but it doesn't remove the old ones.
-        So, if a record is {'field_1': 5} and the schema has the definition
-        {"name": "field_2", "aliases": ["field_1"], "type": "int"}, the resulting record will be
-        {"field_1": 5, "field_2": 5}.
+        """Execute the function of this applier.
+
+        Rename the fields of the input record using the "aliases" value of
+        each field and following the Avro convention. The renaming process
+        creates new fields, but it does not remove the old ones.
+
+        For example, if a record is:
+            {'field_1': 5}
+        and the schema has the definition:
+            {"name": "field_2", "aliases": ["field_1"], "type": "int"}
+        the resulting record will be:
+            {"field_1": 5, "field_2": 5}
+
+        As an applier, the output is the transformed record and schema.
+        In RenameApplier, only the record is transformed.
 
         :param flat_record: The input flat record.
         :type flat_record: dict
@@ -32,12 +44,12 @@ class RenameApplier(object):
 
         new_record = {**flat_record}
 
-        # Rename each file of the original record
-        for key, field_data in flat_schema.items():
+        # Rename each field from the original record (if corresponds).
+        for field_key, field_data in flat_schema.items():
 
             for alias in field_data.aliases:
-                # As tuple key
+                # The identifier keys in records are tuples.
                 if (alias,) in new_record:
-                    new_record[key] = new_record[(alias,)]
+                    new_record[field_key] = new_record[(alias,)]
 
-        return (new_record, flat_schema)
+        return new_record, flat_schema

--- a/RecordMapper/appliers/TransformApplier.py
+++ b/RecordMapper/appliers/TransformApplier.py
@@ -10,8 +10,11 @@ class TransformApplier(object):
     """
 
     def __init__(self, custom_variables: dict):
-        """The constructor of the applier. It accepts a 'custom_variables' argument that its value
-        will be passed to functions.
+        """The constructor of the applier.
+
+        It accepts a 'custom_variables' argument. Its value
+        will be passed to transforming functions.
+
         :param custom_variables: A dict of custom variables.
         :type custom_variables: dict
         """
@@ -19,9 +22,14 @@ class TransformApplier(object):
         self.custom_variables = custom_variables
 
     def apply(self, flat_record: dict, flat_schema: dict) -> (dict, dict):
-        """Executes the function of this applier. It executes the defined functions in "transform"
-        value in several phases. Each phase receives the resulting record of the previous one (except the first
-        phase, that receives the initial record)-
+        """Execute the function of this applier.
+
+        It executes the defined functions in "transform" value in several
+        phases. Each phase receives the resulting record of the previous
+        one (except the first phase, that receives the initial record).
+
+        As an applier, the output is the transformed record and schema.
+        In TransformApplier, only the record is transformed.
 
         :param flat_record: The input record.
         :type flat_record: dict
@@ -31,25 +39,26 @@ class TransformApplier(object):
         :rtype: (dict, dict)
         """
 
-        # The maximum of transform phases to perform
+        # The maximum number of transform phases to perform.
         max_phases = max([len(field_data.transforms) for _, field_data in flat_schema.items()])
-        # Initial copy of the record
+
+        # Initial copy of the record, which will be transformed.
         new_record = {**flat_record} 
 
-        # Iterate over phases and get the transform_functions
+        # Iterate over different phases getting the transforming functions.
         for phase_index in range(max_phases):
             new_values_in_this_phase = {}
             transforms_by_key = [
                (field_key, field_data.transforms[phase_index])
                for field_key, field_data in flat_schema.items()
                if phase_index < len(field_data.transforms) and field_data.transforms[phase_index] is not None
-            ] 
+            ]
 
-            # Iterate over the transform functions
+            # Iterate over the transform functions.
             for key, transform_function in transforms_by_key:
                 res = transform_function(new_record.get(key), new_record, flat_schema, self.custom_variables)
 
-                # If res is a single value, it modifies only the current value
+                # If res is a single value, it modifies only the current value.
                 if type(res) is not tuple:
                     new_values_in_this_phase[key] = res
                 # If res is a tuple of two values and the second one is a dict, it adds the first one as usually
@@ -57,10 +66,10 @@ class TransformApplier(object):
                 elif type(res) is tuple and len(res) == 2 and type(res[1]) is dict:
                     new_values_in_this_phase[key] = res[0]
                     new_values_in_this_phase.update(res[1])
-                # Otherwise, it is not a valid result
+                # Otherwise, it is not a valid result.
                 else:
                     raise RuntimeError(f"Invalid result in a transform function of the key: '{key}'")
             
             new_record = {**new_record, **new_values_in_this_phase}
 
-        return new_record, flat_schema 
+        return new_record, flat_schema

--- a/RecordMapper/avro/AvroReader.py
+++ b/RecordMapper/avro/AvroReader.py
@@ -4,20 +4,20 @@ import fastavro
 
 from RecordMapper.common import Reader
 
-class AvroReader(Reader):
-    """A Record reader from Avro format.
-    """
 
-    def __init__(self, path_to_read: str):
+class AvroReader(Reader):
+    """A Record reader for Avro format."""
+
+    def __init__(self, file_path: str):
         """Constructor of the AvroRecord.
 
-        :param path_to_read: Path of the file to read.
-        :type path_to_read: string
+        :param file_path: Path of the file to read.
+        :type file_path: string
         """
 
-        super().__init__(path_to_read)
-
-        self.read_options ="rb"
+        super().__init__(file_path)
+        self.read_options = "rb"
+        self.reader = None
 
     def read_records_from_input(self, input_stream: BinaryIO) -> Iterator[dict]:
         """Read records from an input stream in avro format.
@@ -28,6 +28,8 @@ class AvroReader(Reader):
         :rtype: Iterator[dict]
         """
 
-        for record in fastavro.reader(input_stream):
+        self.reader = fastavro.reader(input_stream)
+
+        for record in self.reader:
             yield record
 

--- a/RecordMapper/builders/FlatRecordBuilder.py
+++ b/RecordMapper/builders/FlatRecordBuilder.py
@@ -3,52 +3,62 @@
 class FlatRecordBuilder(object):
     """A builder of FlatRecords.
     
-    A 'FlatRecord' is a Record whose keys are tuples. The keys of nested keys will be 'flatted'.
-    For example:
+    A 'FlatRecord' is a record whose keys are tuples.
+    The keys of nested keys will be flattened.
 
-    {
+    For example, for a normal record which look like this:
+      {
         "field_1": 5,
         "field_2": {
-            "field_x": 7,
-            "field_y": 9
+          "field_x": 7,
+          "field_y": 9
         }
-    }
+      }
 
     The FlatRecord will be:
-    {
+      {
         ("field_1",): 5,
         ("field_2","field_x"): 7,
         ("field_2","field_y"): 9
-    }
+      }
     """
 
     @staticmethod
     def get_flat_record_from_normal_record(record: dict) -> dict:
-        """Flattens a record.
+        """Flatten a record.
+
+        Iterate over a record fields to return a flattened version
+        of the record. Apply recurrently this method to each nested
+        field inside the original field.
 
         :param record: The input record.
         :type record: dict
-        :return: A flat record.
+        :return: The flattened record.
         :rtype: dict
         """
-        res = {}
+
+        flat_record = {}
         for key, value in record.items():
             flat_key = (key,)
             if isinstance(value, dict):
                 subrecord = FlatRecordBuilder.get_flat_record_from_normal_record(value)
-                res.update({flat_key+flat_subkey: subvalue for flat_subkey, subvalue in subrecord.items()})
+                flat_record.update({flat_key+flat_subkey: subvalue
+                                    for flat_subkey, subvalue in subrecord.items()})
             else:
-                res.update({flat_key: value})
+                flat_record.update({flat_key: value})
 
-        return res 
+        return flat_record
     
     @staticmethod
     def get_normal_record_from_flat_record(flat_record: dict) -> dict:
-        """
-        Return a "normal record" from a FlatRecord.
-        :param flat_record: A flat record.
+        """Return a normal record from a FlatRecord.
+
+        Convert a FlatRecord object, a tuple-key dictionary,
+        into a nested-key dictionary record.
+
+        :param flat_record: The flat record.
         :type flat_record: dict
-        :return: A normal record.
+        :return: The normal record.
         :rtype: dict
         """
 
@@ -56,12 +66,10 @@ class FlatRecordBuilder(object):
         for composed_key, value in flat_record.items():
             if len(composed_key) == 1:
                 res_record[composed_key[0]] = value
-
             elif len(composed_key) == 2:
                 super_key, nested_key = composed_key
                 if super_key not in res_record:
                     res_record[super_key] = {}
-                
                 if isinstance(res_record[super_key], dict):
                     res_record[super_key][nested_key] = value
                 else:

--- a/RecordMapper/builders/FlatSchemaBuilder.py
+++ b/RecordMapper/builders/FlatSchemaBuilder.py
@@ -5,17 +5,23 @@ from RecordMapper.builders import FunctionBuilder
 
 FieldData = namedtuple("FieldData", ["types", "aliases", "transforms", "selector"])
 
+
 class FlatSchemaBuilder(object):
-    """A builder class that creates a FlatSchema.
-    """
+    """A builder class that creates a FlatSchema."""
 
     @staticmethod
     def get_flat_schema(schema: dict) -> dict:
-        """Creates a FlatSchema from a normal avro Schema.
+        """Create a FlatSchema from a standard Avro schema.
 
-        A FlatSchema is a dict where the keys are tuples and the values "FieldData" objects.
+        A FlatSchema represents an Avro schema converted to a dict,
+        where the keys are tuples and the values "FieldData" objects:
+          - The keys are used to identify uniquely the field.
+            For example using the field name.
+          - The FieldData objects contain all the information
+            that define a field, including types, aliases,
+            transformations and selectors.
 
-        :param schema: Normal Avro schema. 
+        :param schema: Standard Avro schema.
         :type schema: dict
         :return: A FlatSchema.
         :rtype: dict
@@ -33,18 +39,20 @@ class FlatSchemaBuilder(object):
             field_transforms = FlatSchemaBuilder.get_transform_functions_from_field(field.get("transform", None)) 
             field_selector = FlatSchemaBuilder.get_selector_function(field.get("nestedSchemaSelector", None))
 
-            field_data = FieldData(field_types, field_aliases, field_transforms, field_selector) 
+            field_data = FieldData(field_types, field_aliases, field_transforms, field_selector)
 
-            # Key as tuple
+            # Add each field, identified by its name and defined by its metadata, to the flatted schema.
             flat_schema[(field_name,)] = field_data
         
         return flat_schema
 
     @staticmethod
     def get_transform_functions_from_field(transform_field: Union[str, List[str]]) -> List[Callable]:
-        """Generate a list of transform functions from a list of string values (or a single string value).
+        """Generate a list of transform functions from a list of string
+        values (or a single string value).
 
-        :param transform_field: A list of string values (or a single string value) that reference one or several transform functions.
+        :param transform_field: A list of string values (or a single string value)
+          that reference one or several transform functions.
         :type transform_field: Union[str, List[str]]
         :return: List of transform functions.
         :rtype: List[Callable]

--- a/RecordMapper/builders/FunctionBuilder.py
+++ b/RecordMapper/builders/FunctionBuilder.py
@@ -7,7 +7,9 @@ from RecordMapper.builders import BuiltinFunctions
 
 
 class InvalidFunctionError(Exception):
-    """An exception that represents an invalid string reference for a function"""
+    """
+        An exception that represents an invalid string reference for a function.
+    """
     pass
 
 

--- a/RecordMapper/common/Reader.py
+++ b/RecordMapper/common/Reader.py
@@ -2,17 +2,16 @@ from typing import BinaryIO, Iterator
 
 
 class Reader(object):
-    """A generic Reader object.
-    """
+    """A generic Reader object."""
 
-    def __init__(self, path_to_read: str):
-        """The constructor function.
+    def __init__(self, file_path: str):
+        """The constructor method.
 
-        :param path_to_read: The path to read. 
-        :type path_to_read: str
+        :param file_path: Path of the file to read.
+        :type file_path: str
         """
 
-        self.file_path = path_to_read
+        self.file_path = file_path
         self.read_options = "r"
         self.input_stream = None
 
@@ -28,12 +27,13 @@ class Reader(object):
         return self.read_records_from_input(self.input_stream)
 
     def read_records_from_input(self, input_stream: BinaryIO) -> Iterator[dict]:
-        """This function reads from the input object and returns a generator of records.
-        This has to be implemented by a child class.
+        """Read from the input object and return a generator of records.
+
+        This method has to be implemented by a child class.
 
         :param input_stream: An input stream.
         :type input_stream: BinaryIO.
-        :raises NotImplementedError: This function has to be implemented by a child class.
+        :raises NotImplementedError: The method has to be implemented by a child class.
         :yield: A read record.
         :rtype: Iterator[dict]
         """
@@ -41,7 +41,6 @@ class Reader(object):
         raise NotImplementedError("This method has to be implemented to read formatted records!")
 
     def close(self):
-        """This method close the input stream.
-        """
+        """Close the input stream."""
 
         self.input_stream.close()

--- a/RecordMapper/common/Writer.py
+++ b/RecordMapper/common/Writer.py
@@ -2,26 +2,29 @@ from typing import BinaryIO, Iterable
 
 
 class Writer(object):
-    """The generic writer class.
-    """
+    """The generic writer class."""
 
     def __init__(self, file_path: str):
-        """The constructor function.
+        """The constructor method.
 
-        :param file_path: The path of the input file. 
+        :param file_path: Path of the input file.
         :type file_path: str
         """
 
         self.file_path = file_path
         self.write_options = "w"
-
         self.output_stream = None
 
     def write_records(self, records: Iterable, output_opts: dict):
-        """This function writes the records to the output file.
+        """Write the records to the output file.
+
+        Include a set of options to modify the writing process.
 
         :param records: An iterable of records.
         :type records: Iterable
+        :param output_opts: A dict-like set of options to be able to handle the
+            behaviour of the output.
+        :type output_opts: dict
         :return: A generator of records.
         :rtype: Iterator[dict]
         """
@@ -31,20 +34,23 @@ class Writer(object):
         return self.write_records_to_output(records, self.output_stream, output_opts)
 
     def write_records_to_output(self, records: Iterable, output: BinaryIO, output_opts: dict):
-        """Write the records to an output file. This function has to be implemented by a
-        child class.
+        """Write the records to an output file.
+
+        This method has to be implemented by a child class.
 
         :param records: An iterable of records.
         :type records: Iterable
         :param output: An output stream.
         :type output: BinaryIO
-        :raises NotImplementedError: This function has to be implemented by a child class.
+        :param output_opts: A dict-like set of options to be able to handle the
+            behaviour of the output.
+        :type output_opts: dict
+        :raises NotImplementedError: The method has to be implemented by a child class.
         """
 
         raise NotImplementedError("This method has to be implemented to write formatted records!")
 
     def close(self):
-        """This function close the output stream.
-        """
+        """Close the output stream."""
 
         self.output_stream.close()

--- a/RecordMapper/csv/CSVReader.py
+++ b/RecordMapper/csv/CSVReader.py
@@ -8,26 +8,25 @@ csv.field_size_limit(100_000_000)
 
 
 class CSVReader(Reader):
-    """A object that reads records form an input csv file.
-    """
+    """A Record reader for csv format."""
 
     def __init__(self, file_path: str):
         """The constructor of the CSVReader.
 
-        :param input: The path of the file.
-        :type input: str
+        :param file_path: Path of the file to read
+        :type file_path: str
         """
 
         super().__init__(file_path)
-        self.filepath = file_path
+        self.reader = None
 
     def read_records_from_input(self, input_stream: BinaryIO) -> Iterator[dict]:
-        """The function that reads the records from the input stream.
+        """Read records from an input stream in csv format.
 
         :param input_stream: The input stream of the records.
         :type input_stream: BinaryIO
-        :yield: dict
-        :rtype: 
+        :yield: A record.
+        :rtype: Iterator[dict]
         """
 
         self.reader = csv.DictReader(input_stream)

--- a/RecordMapper/csv/CSVWriter.py
+++ b/RecordMapper/csv/CSVWriter.py
@@ -6,16 +6,15 @@ from RecordMapper.common import Writer
 
 
 class CSVWriter(Writer):
-    """The object that writes records to a csv file.
-    """
+    """A Record reader for csv format."""
 
     def __init__(self, file_path: str, fieldnames: List[str]):
         """The constructor of the CSVWriter.
 
-        :param file_path: The path to write.
-        :type file_path: object.
-        :param fieldnames: The list of names of the columns.
-            Their order will be preserved in the result file.
+        :param file_path: Path to write.
+        :type file_path: str
+        :param fieldnames: List of names of the columns. Their order will
+            be preserved in the results file.
         :type fieldnames: List[str]
         """
 
@@ -24,12 +23,17 @@ class CSVWriter(Writer):
         self.write_count = 0
 
     def write_records_to_output(self, records: Iterable[dict], output: BinaryIO, output_opts: dict):
-        """Writes the records to an output file.
+        """Write the records to the output file.
+
+        As output options, we can include the flatting of the nested schemas.
 
         :param records: An iterable of records.
         :type records: List[dict]
         :param output: The object to write.
         :type output: BinaryIO
+        :param output_opts: A dict-like set of options to be able to handle the
+            behaviour of the output.
+        :type output_opts: dict
         """
 
         fields_to_flat = set(output_opts.get("flat_nested_schema_on_csv", dict()).keys())
@@ -48,13 +52,14 @@ class CSVWriter(Writer):
             self.write_count += 1
 
     def format_record(self, record: dict, fields_to_flat: set) -> dict:
-        """Format a record to be written. For example, dicts will be serialized to
-        JSON strings.
+        """Format a record to be written.
+
+        For example, dicts will be serialized to JSON strings.
 
         :param record: A input record.
         :type record: dict
         :param fields_to_flat: A set of fields that will be flatted.
-        :type flatten: set
+        :type fields_to_flat: set
         :return: A formatted record to be written.
         :rtype: dict
         """

--- a/RecordMapper/csv/CSVWriter.py
+++ b/RecordMapper/csv/CSVWriter.py
@@ -58,11 +58,14 @@ class CSVWriter(Writer):
 
         :param record: A input record.
         :type record: dict
-        :param fields_to_flat: A set of fields that will be flatted.
+        :param fields_to_flat: A set of fields that will be flattened.
         :type fields_to_flat: set
         :return: A formatted record to be written.
         :rtype: dict
         """
+
+        if fields_to_flat:
+            record = self.prepare_nested_fields_to_flatten(record, fields_to_flat)
 
         record_to_write = {**record}
 
@@ -75,3 +78,23 @@ class CSVWriter(Writer):
                     record_to_write[key] = json.dumps(value)
 
         return record_to_write
+
+    def prepare_nested_fields_to_flatten(self, record: dict, fields_to_flat: set) -> dict:
+        """Prepare the nested fields to be flattened in record formatting.
+
+        To properly format a record with nested fields, they must
+        be Python dictionary.
+
+        :param record: The input record.
+        :type record: dict
+        :param fields_to_flat: A set of fields that will be flattened.
+        :type fields_to_flat: set
+        :return: The record after corrections.
+        :rtype: dict
+        """
+
+        for field_to_flat in fields_to_flat:
+            if field_to_flat in record:
+                record[field_to_flat] = record[field_to_flat] if record[field_to_flat] else {}
+
+        return record

--- a/RecordMapper/utils.py
+++ b/RecordMapper/utils.py
@@ -1,9 +1,20 @@
 from typing import Callable, List
 
+
 def chain_functions(*functions_list: List[Callable]) -> Callable:
-    """A helper function that creates another one that executes all the functions
-    defined in functions_list in a waterfall way. 
+    """Chain the given functions in a single pipeline.
+
+    A helper function that creates another one that invoke
+    all the given functions (defined in functions_list) in
+    a waterfall way.
+
+    The given functions should have the same input/output
+    interface in order to run properly as a pipeline.
+
     :param functions_list: A list of functions.
+    :type functions_list: List[Callable]
+    :return:
+    :rtype: Callable
     """
 
     def wrapper_function(*input_args: List[object]) -> tuple:
@@ -20,12 +31,14 @@ def chain_functions(*functions_list: List[Callable]) -> Callable:
 
 
 def object_as_tuple(obj: object) -> tuple:
-    """Transforms an object into a tuple (except if this object is already a tuple).
+    """Transform an object into a tuple.
 
-    :param obj: An object 
+    If the given objet is already a tuple, just return it.
+
+    :param obj: A given object
     :type obj: object
-    :return: 
-    :rtype: [type]
+    :return: The object as a tuple.
+    :rtype: tuple
     """
 
     if isinstance(obj, tuple):

--- a/RecordMapper/xml/XMLReader.py
+++ b/RecordMapper/xml/XMLReader.py
@@ -4,30 +4,30 @@ from defusedxml.ElementTree import parse as parse_xml
 
 from RecordMapper.common import Reader
 
+
 class XMLReader(Reader):
-    """A object that reads records form an input xml file.
-    """
+    """A Record reader for xml format."""
 
     def __init__(self, file_path: str):
         """The constructor of the XMLReader.
 
-        :param input: The path of the file.
-        :type input: str
+        :param file_path: Path of the file to read.
+        :type file_path: str
         """
 
         super().__init__(file_path)
-        self.filepath = file_path
+        self.reader = None
 
     def read_records_from_input(self, input_stream: BinaryIO) -> Iterator[dict]:
-        """The function that reads the records from the input stream.
+        """Read records from an input stream in xml format.
 
         :param input_stream: The input stream of the records.
         :type input_stream: BinaryIO
-        :yield: dict
-        :rtype: 
+        :yield: A record.
+        :rtype: Iterator[dict]
         """
 
         self.reader = parse_xml(input_stream).getroot()
 
         for record in self.reader:
-            yield {attribute.tag : attribute.text for attribute in record}
+            yield {attribute.tag: attribute.text for attribute in record}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [tool]
 [tool.poetry]
 name = "RecordMapper"
-version = "0.6.3"
-description = "Transform records using an Avro Schema and custom map functions"
+version = "0.7"
+description = "Transform records using an Avro schema and custom map functions."
 classifiers = ["License :: OSI Approved :: MIT License"]
 homepage = "https://github.com/urbandataanalytics/RecordMapper"
-authors = ["UDARealState Data engineering Team"]
+authors = ["uDARealEstate Data Engineering Team"]
 readme = "README.md"
 
 packages = [
@@ -17,6 +17,6 @@ packages = [
 python = "^3.7"
 coverage = "~4.5.4"
 dateparser = "~1.0.0"
-defusedxml = "~0.6.0"
-fastavro = "~0.23.4"
+defusedxml = "~0.7.1"
+fastavro = "~1.4"
 nose = "~1.3.7"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 DEPENDENCIES = [
     'coverage==4.5.4',
     'nose==1.3.7',
-    'fastavro==0.23.4',
+    'fastavro==1.4',
     'defusedxml==0.6.0',
     'dateparser==1.0.0'
 ]
@@ -17,7 +17,7 @@ setuptools.setup(
     description='Transform records using an Avro Schema and custom map functions',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    author='UDARealState Data engineering Team',
+    author='uDARealEstate Data Engineering Team',
     url='https://github.com/urbandataanalytics/RecordMapper',
     install_requires=DEPENDENCIES,
     packages=setuptools.find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ DEPENDENCIES = [
     'coverage==4.5.4',
     'nose==1.3.7',
     'fastavro==1.4',
-    'defusedxml==0.6.0',
+    'defusedxml==0.7.1',
     'dateparser==1.0.0'
 ]
 
@@ -13,8 +13,8 @@ with open('README.md', encoding='utf-8') as f:
 
 setuptools.setup(
     name='RecordMapper',
-    version='0.6.3',
-    description='Transform records using an Avro Schema and custom map functions',
+    version='0.7',
+    description='Transform records using an Avro schema and custom map functions.',
     long_description=long_description,
     long_description_content_type='text/markdown',
     author='uDARealEstate Data Engineering Team',


### PR DESCRIPTION
Revisión de código de RecordMapper. Muchos cambios únicamente de documentación.

El único cambio significativo es el método añadido al CSVWriter para que pueda escribir esquemas anidados aún cuando éstos no tengan datos. Hasta ahora, en la escritura a csv se aplanan los campos anidados, que están en formato diccionario. El problema es que si dichos campos no tienen contenido (por ejemplo una tipología que no tenga características distintivas para una fuente) ese campo NO es un diccionario, no se puede aplanar y rompe la escritura. La función lo que hace es, si no existe dicho campo, lo crea como un diccionario vacío (anidado oficioso) para que sea aplanable.